### PR TITLE
Feature/update xunit and test projects

### DIFF
--- a/Xunit.Di.Ci.Tests/Xunit.Di.Ci.Tests.csproj
+++ b/Xunit.Di.Ci.Tests/Xunit.Di.Ci.Tests.csproj
@@ -9,10 +9,7 @@
   <Import Project="..\Xunit.Di\targets\Xunit.Di.targets" />
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-    <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/Xunit.Di.Ci.Tests/Xunit.Di.Ci.Tests.csproj
+++ b/Xunit.Di.Ci.Tests/Xunit.Di.Ci.Tests.csproj
@@ -1,20 +1,22 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <Import Project="..\Xunit.Di\targets\Xunit.Di.targets" />
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.0.2">
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Xunit.Di.Tests/Xunit.Di.Tests.csproj
+++ b/Xunit.Di.Tests/Xunit.Di.Tests.csproj
@@ -1,17 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 
+    <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
     <PackageReference Include="Xunit.Di" Version="2.4.5" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Xunit.Di.Tests/Xunit.Di.Tests.csproj
+++ b/Xunit.Di.Tests/Xunit.Di.Tests.csproj
@@ -9,9 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="5.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-    <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="Xunit.Di" Version="2.4.5" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Xunit.Di.Tests/Xunit.Di.Tests.csproj
+++ b/Xunit.Di.Tests/Xunit.Di.Tests.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
-    <PackageReference Include="Xunit.Di" Version="2.4.5" />
+    <PackageReference Include="Xunit.Di" Version="*" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/Xunit.Di/Xunit.Di.csproj
+++ b/Xunit.Di/Xunit.Di.csproj
@@ -20,8 +20,8 @@ Installing this package installs xunit, Microsoft.Extensions.Hosting and their d
     <Content Include="targets\$(PackageId).targets" PackagePath="build\$(PackageId).targets" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
+    <PackageReference Include="xunit" Version="2.5.0" />
   </ItemGroup>
   <ItemGroup>
     <None Update="targets\Xunit.Di.targets">

--- a/Xunit.Di/Xunit.Di.csproj
+++ b/Xunit.Di/Xunit.Di.csproj
@@ -3,10 +3,10 @@
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <PackageId>Xunit.Di</PackageId>
-    <Version>2.4.5</Version>
+    <Version>2.4.6</Version>
     <Authors>Clix Contributors</Authors>
     <Company>Clix</Company>
-    <PackageTags>xunit; dependency; injection; automation; test; unit; xunit.di</PackageTags>    
+    <PackageTags>xunit; dependency; injection; automation; test; unit; xunit.di</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryUrl>https://github.com/clix455/Xunit.Di</RepositoryUrl>
     <PackageProjectUrl>https://github.com/clix455/Xunit.Di</PackageProjectUrl>


### PR DESCRIPTION
The main change in the project is the upgrade of the Xunit library, which will allow the package to be used in projects with dependencies in a higher version. This change is dictated by the inability to use Xunit.Di and Verify.Xunit in the same project.

Additionally
- removing unused libraries from projects
- updating test projects to use .Net version 7